### PR TITLE
Relative paths

### DIFF
--- a/1_hello_tensorflow.ipynb
+++ b/1_hello_tensorflow.ipynb
@@ -711,7 +711,7 @@
    "source": [
     "## What's next?\n",
     "\n",
-    "This has been a gentle introduction to TensorFlow, focused on what TensorFlow is and the very basics of doing anything in TensorFlow. If you'd like more, the next tutorial in the series is Getting Started with TensorFlow, also available in the [notebooks directory](http://127.0.0.1:8888/tree)."
+    "This has been a gentle introduction to TensorFlow, focused on what TensorFlow is and the very basics of doing anything in TensorFlow. If you'd like more, the next tutorial in the series is Getting Started with TensorFlow, also available in the [notebooks directory](..)."
    ]
   }
  ],

--- a/2_getting_started.ipynb
+++ b/2_getting_started.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "This is an introduction to working with TensorFlow. It works through an example of a very simple neural network, walking through the steps of setting up the input, adding operators, setting up gradient descent, and running the computation graph. \n",
     "\n",
-    "This tutorial presumes some familiarity with the TensorFlow computational model, which is introduced in the [Hello, TensorFlow](http://127.0.0.1:8888/tree) notebook, also available in this bundle."
+    "This tutorial presumes some familiarity with the TensorFlow computational model, which is introduced in the [Hello, TensorFlow](../notebooks/1_hello_tensorflow.ipynb) notebook, also available in this bundle."
    ]
   },
   {


### PR DESCRIPTION
This PR just switches to relative paths for the inter-notebook links, so the links work when navigating between notebooks inside a hosted environment (like Binder).
